### PR TITLE
Use new cakephp/plugin-installer properly in composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,15 @@
   "require": {
     "composer/installers": "*"
   },
-  "extra": {
-    "installer-name": "ConfigRead"
+  "autoload": {
+    "psr-4": {
+      "ConfigRead\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "ConfigRead\\Test\\": "tests",
+      "Cake\\Test\\": "vendor/cakephp/cakephp/test"
+    }
   }
 }


### PR DESCRIPTION
Corrects the composer.json file for the Cake 3 branch (master) to use the new `cakephp/plugin-installer`.

For reference, it uses the `autoload` key to determine the installation path for the plugin as `vendors/loadsys/config-read/src/`.

Compare this to the old `composer/installers` process that required setting an `extra: { installer-name: ConfigRead }` key to force the plugin to be installed in `Plugins/ConfigRead/` in Cake 2.