### PR TITLE
Fix special key matching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ The ConfigReadShell devotes about half of its codebase dealing with this for you
 
 The "gotcha" here is that ConfigReadShell has to maintain a static list of Configure keys that are consumed, and how to access them in their new container. **If your app consumes a non-standard Configure key during bootstrapping, you will not be able to obtain it from the ConfigReadShell.**
 
+An additionally exception is `EmailTransport`, which doesn't have a way of enumerating the named configs it is storing. Basically: `EmailTransport.default` will work, but just `EmailTransport` will not. (This caveat will no longer be an issue if cakephp/cakephp#6969 is merged.)
+
 
 ## Contributing
 

--- a/src/Shell/ConfigReadShell.php
+++ b/src/Shell/ConfigReadShell.php
@@ -231,7 +231,7 @@ class ConfigReadShell extends Shell {
 	protected function specialKey($search) {
 		$callable = false;
 		foreach ($this->specialKeys as $key => $call) {
-			if (strpos($search, $key) === 0) {
+			if (strpos("{$search}.", "{$key}.") === 0) {
 				$callable = $call;
 			}
 		}
@@ -281,11 +281,10 @@ class ConfigReadShell extends Shell {
 		if (isset($special['arg'])) {
 			$set = call_user_func($special['callable'], $special['arg']);
 		} else {
-			$allConfigCallable = preg_replace(
-				'/::config$/',
+			$allConfigCallable = str_replace(
+				'::config',
 				'::configured',
 				$special['callable'],
-				-1,
 				$replaceCount
 			);
 


### PR DESCRIPTION
Also plan ahead for cakephp/cakephp#6969 getting merged, allowing `Email::configTransport()`s to be enumerated by calling `Email::configuredTransport()`.