### PR TITLE
Update Shell for Cake 3.6 compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,13 @@ language: php
 sudo: false
 
 php:
-  - 5.6
+  - 7.2
 
 # Environment Variables to set
 env:
   global:
     # Contains a $GITHUB_TOKEN env var for use with composer to avoid API limits.
     - secure: "JPIIdecDmF2AsgH3b5QWYzr2TunB4tpIBl0/64EGsWZ+5A85Co3NN+eSshgWI5vOjaaJji/S2rKwMRvV9h/YceTL/UH5D2xd/HobRpHAaJSyjp5cplQawokzR/+PrikjmbwTZdeiIaHpUMCqbQvV2+Jq+Vx5vD28+hya1yTdQsk="
-
 
 # Cache the composer directories, only allowed if using the container based setup
 # which depends on setting sudo to false
@@ -29,8 +28,7 @@ before_install:
   - mkdir -p build/logs
 
 install:
-  - composer config -g github-oauth.github.com $GITHUB_TOKEN
-  - composer install --no-interaction
+  - composer install --dev --no-interaction
 
 before_script:
   - phpenv rehash
@@ -40,8 +38,8 @@ script:
   - vendor/bin/phpcs -np --extensions=php --standard=Loadsys ./src ./tests
   - vendor/bin/phpunit --coverage-clover=build/logs/clover.xml
 
-after_script:
-  - php vendor/bin/coveralls -v
+after_success:
+  - travis_retry php vendor/bin/php-coveralls -v
 
 notifications:
   email: false

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-Copyright (c) 2015 Loadsys Web Strategies
+Copyright (c) 2018 Loadsys Web Strategies
 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ A CakePHP plugin that provides a Shell to read an app's Configure vars from the 
 
 ## Requirements
 
-* CakePHP 3.1.0+
-* PHP 5.6+
+* PHP 7.0+
+* CakePHP 3.6.0+
 
 
 ## Installation
@@ -143,4 +143,4 @@ When developing this plugin, please fork and issue a PR for any new development.
 
 ## Copyright
 
-[Loadsys Web Strategies](http://www.loadsys.com) 2016
+[Loadsys Web Strategies](http://www.loadsys.com) 2018

--- a/README.md
+++ b/README.md
@@ -8,22 +8,29 @@
 
 A CakePHP plugin that provides a Shell to read an app's Configure vars from the command line.
 
-* This is the Cake 3.x version of the plugin, which exists on the `master` branch and is tracked by the `~3.0` semver.
-* For the Cake 2.x version of this plugin, please use the repo's `cake-2.x` branch. (semver `~2.0`)
-* For the Cake 1.3 version, use the `cake-1.3` branch. (semver `~1.0`) **Note:** we don't expect to actively maintain or improve the 1.3 version. It's here because the project started life as a 1.3 Shell.
+## Installation
+Use the following as a guide for choosing your version based on the version of CakePHP installed.
 
+| CakePHP | ConfigReadShell Plugin | Tag   | Notes |
+| :-------------: | :------------------------: | :--:  | :---- |
+| ^3.4            | [master](https://github.com/loadsys/CakePHP-ConfigReadShell/tree/master)            | 4.0.0 | stable   |
+| 3.3             | [3.3](https://github.com/loadsys/CakePHP-ConfigReadShell/tree/3.0.0)                | 3.0.0 | stable   |
+| 2.5             | [2.x](https://github.com/loadsys/CakePHP-ConfigReadShell/tree/2.0.1)                | 2.0.1 | stable   |
+| 1.3             | [1.x](https://github.com/loadsys/CakePHP-ConfigReadShell/tree/1.0.1)                  | 1.0.1   | stable   |
+
+
+### This will install the latest version.
+```bash
+$ composer require loadsys/cakephp-config-read:~4.0
+```
+
+**Note:** we don't expect to actively maintain or improve the 1.3 version. It's here because the project started life as a 1.3 Shell.
 
 ## Requirements
 
 * PHP 7.0+
 * CakePHP 3.6.0+
 
-
-## Installation
-
-```bash
-$ composer require loadsys/cakephp-config-read:~3.0
-```
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -105,19 +105,19 @@ Array
 
 CakePHP 3 by default "consumes" some of its configs so as not to confuse developers. [`Configure::consume()`](http://book.cakephp.org/3.0/en/development/configuration.html#Cake\Core\Configure::consume) removes the configuration key from Configure, making it unavailable to the rest of the app. At the [time of this writing](https://github.com/cakephp/app/blob/a0f2c4/config/bootstrap.php#L136,L141), it does this for the following keys/classes:
 
-| _`[Configure.Key]`_  | _`Class::configEnumerationMethod()`_  | _`Class::configFetchMethod()`_  |
-|----------------------|---------------------------------------|---------------------------------|
-| `[Cache]`            | `Cache::configured()`                 | `Cache::config()`               |
-| `[Datasources]`      | `ConnectionManager::configured()`     | `ConnectionManager::config()`   |
-| `[EmailTransport]`   | `Email::configuredTransport()`        | `Email::configTransport()`      |
-| `[Email]`            | `Email::configured()`                 | `Email::config()`               |
-| `[Log]`              | `Log::configured()`                   | `Log::config()`                 |
-| `[Security.salt]`    | _(none)_                              | `Security::salt()`              |
+| _`[Configure.Key]`_  | _`Class::configEnumerationMethod()`_  | _`Class::configFetchMethod()`_    |
+|----------------------|---------------------------------------|-----------------------------------|
+| `[Cache]`            | `Cache::configured()`                 | `Cache::getConfig()`              |
+| `[Datasources]`      | `ConnectionManager::configured()`     | `ConnectionManager::getConfig()`  |
+| `[EmailTransport]`   | `Email::configuredTransport()`        | `Email::getConfigTransport()`     |
+| `[Email]`            | `Email::configured()`                 | `Email::getConfig()`              |
+| `[Log]`              | `Log::configured()`                   | `Log::getConfig()`                |
+| `[Security.salt]`    | _(none)_                              | `Security::getSalt()`             |
 
 
-The ConfigReadShell devotes about half of its codebase dealing with this for you, allowing you to continue to fetch values using the Configure path (`Datasources.default.host` -> `localhost`) while in the background it is actually querying `ConnectionManager::config('default')['host']`. (This is particularly helpful if you are using [Environment-Aware Configs](https://github.com/beporter/CakePHP-EnvAwareness/tree/master/slides).)
+The ConfigReadShell devotes about half of its codebase dealing with this for you, allowing you to continue to fetch values using the Configure path (`Datasources.default.host` -> `localhost`) while in the background it is actually querying `ConnectionManager::getConfig('default')['host']`. (This is particularly helpful if you are using [Environment-Aware Configs](https://github.com/beporter/CakePHP-EnvAwareness/tree/master/slides).)
 
-The "gotcha" here is that ConfigReadShell has to maintain a hard-coded list of Configure keys that are normally consumed, and how to access them in their new container. This is further complicated by the fact that not all consumed configs are loaded into or retrieved from their containers the same way, although the base assumption is that the container implements the [`StaticConfigTrait`](http://api.cakephp.org/3.0/class-Cake.Core.StaticConfigTrait.html) and so will have `::config()` and `::configured()` available.
+The "gotcha" here is that ConfigReadShell has to maintain a hard-coded list of Configure keys that are normally consumed, and how to access them in their new container. This is further complicated by the fact that not all consumed configs are loaded into or retrieved from their containers the same way, although the base assumption is that the container implements the [`StaticConfigTrait`](http://api.cakephp.org/3.0/class-Cake.Core.StaticConfigTrait.html) and so will have `::getConfig()` and `::configured()` available.
 
 :warning: **If your app uses `Configure::consume()` on any non-standard Configure key during bootstrapping, you will not be able to obtain any child values of those keys from the ConfigReadShell.**
 

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
     "source": "https://github.com/loadsys/CakePHP-ConfigReadShell"
   },
   "require": {
-    "php": ">=5.4",
-    "cakephp/cakephp": "~3.1",
+    "php": ">=7.0",
+    "cakephp/cakephp": "^3.6",
     "composer/installers": "~1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.1",
+    "phpunit/phpunit": "~6.0",
     "loadsys/loadsys_codesniffer": "dev-master",
-    "satooshi/php-coveralls": "dev-master"
+    "php-coveralls/php-coveralls": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require": {
     "php": ">=7.0",
-    "cakephp/cakephp": "^3.6",
+    "cakephp/cakephp": "^3.4",
     "composer/installers": "~1.0"
   },
   "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,13 +17,9 @@
 
 	<!-- Prevent coverage reports from looking in tests and vendors -->
 	<filter>
-		<blacklist>
-			<directory suffix=".php">./vendor/</directory>
-			<directory suffix=".ctp">./vendor/</directory>
-
-			<directory suffix=".php">./tests/</directory>
-			<directory suffix=".ctp">./tests/</directory>
-		</blacklist>
+		<whitelist>
+			<directory suffix=".php">./src/</directory>
+		</whitelist>
 	</filter>
 
 </phpunit>

--- a/src/Shell/ConfigReadShell.php
+++ b/src/Shell/ConfigReadShell.php
@@ -47,12 +47,12 @@ class ConfigReadShell extends Shell {
 	 * Cake 3 uses Configure::consume() on a number of Configure keys to
 	 * prime different Cake modules in `config/boostrap.php`.
 	 *
-	 * Cache::config(Configure::consume('Cache'));
-	 * ConnectionManager::config(Configure::consume('Datasources'));
-	 * Email::configTransport(Configure::consume('EmailTransport'));
-	 * Email::config(Configure::consume('Email'));
-	 * Log::config(Configure::consume('Log'));
-	 * Security::salt(Configure::consume('Security.salt'));
+	 * Cache::setConfig(Configure::consume('Cache'));
+	 * ConnectionManager::setConfig(Configure::consume('Datasources'));
+	 * Email::setConfigTransport(Configure::consume('EmailTransport'));
+	 * Email::setConfig(Configure::consume('Email'));
+	 * Log::setConfig(Configure::consume('Log'));
+	 * Security::setSalt(Configure::consume('Security.salt'));
 	 *
 	 * This removes the configs from Configure, making them inaccessible
 	 * through standard means in this Shell.
@@ -60,16 +60,16 @@ class ConfigReadShell extends Shell {
 	 * This property tracks specific key names and the class::method they
 	 * map to so we can perform the correct logic to fetch the values. For
 	 * example, a request for `Cache._cake_core_.className` would result
-	 * in a call like `\Cake\Cache\Cache::config('_cake_core_')['className']`.
+	 * in a call like `\Cake\Cache\Cache::getConfig('_cake_core_')['className']`.
 	 *
 	 * @var array
 	 */
 	public $specialKeys = [
-		'Cache' => '\Cake\Cache\Cache::config',
-		'Datasources' => '\Cake\Datasource\ConnectionManager::config',
-		'EmailTransport' => '\Cake\Mailer\Email::configTransport',
-		'Email' => '\Cake\Mailer\Email::config',
-		'Log' => '\Cake\Log\Log::config',
+		'Cache' => '\Cake\Cache\Cache::getConfig',
+		'Datasources' => '\Cake\Datasource\ConnectionManager::getConfig',
+		'EmailTransport' => '\Cake\Mailer\Email::getConfigTransport',
+		'Email' => '\Cake\Mailer\Email::getConfig',
+		'Log' => '\Cake\Log\Log::getConfig',
 		'Security.salt' => 'self::securitySaltHelper',
 	];
 
@@ -100,7 +100,7 @@ class ConfigReadShell extends Shell {
 		}
 
 		// All other output should not be processed by the Shell.
-		$this->_io->outputAs(ConsoleOutput::RAW);
+		$this->_io->setOutputAs(ConsoleOutput::RAW);
 	}
 
 	/**
@@ -262,16 +262,16 @@ class ConfigReadShell extends Shell {
 	 * There are three cases to handle:
 	 *
 	 *   1. A "deep" subkey like `Cache.default.className`. In this case,
-	 *      we need to fetch `Cache::config('default')` and then return
+	 *      we need to fetch `Cache::getConfig('default')` and then return
 	 *      the ['className'] from the result.
 	 *
 	 *   2. A single config array like `Cache.default. We need to fetch
-	 *      `Cache::config('default')` and return the whole thing.
+	 *      `Cache::getConfig('default')` and return the whole thing.
 	 *
 	 *   3. All configs in a module like `Cache`. In this case we need to
 	 *      try calling `Cache::configured()` (if it exists), then looping
 	 *      over the results using each as a key name for a separate call
-	 *      to `Cache::config($name)` and accumulating all of the results
+	 *      to `Cache::getConfig($name)` and accumulating all of the results
 	 *      together to return.
 	 *
 	 * @param array $special An array containing at least a [callable] key and possibly [arg] and [subkey]s.
@@ -282,7 +282,7 @@ class ConfigReadShell extends Shell {
 			$set = call_user_func($special['callable'], $special['arg']);
 		} else {
 			$allConfigCallable = str_replace(
-				'::config',
+				'::getConfig',
 				'::configured',
 				$special['callable'],
 				$replaceCount
@@ -362,20 +362,20 @@ class ConfigReadShell extends Shell {
 	/**
 	 * Provides a custom helper for fetching the App's Security.salt value.
 	 *
-	 * The call to Security::salt() method requires no arguments to get the
+	 * The call to Security::getSalt() method requires no arguments to get the
 	 * current value but we will have split the command line request for
 	 * `Security.salt` into
-	 * `call_user_func('\Cake\Utility\Security::salt', 'salt'). That will
+	 * `call_user_func('\Cake\Utility\Security::getSalt', 'salt'). That will
 	 * **set** the salt to `salt` and return "salt" as the new value, which
 	 * isn't what we want. This method exists to be the callable function,
-	 * which itself passes the proper `null` value as the argument, which
-	 * in turn will return the _actual_ salt value.
+	 * which itself passes no arguments to getSalt, which in turn will return
+	 * the _actual_ salt value.
 	 *
 	 * @param string $salt Because of how this is implemented, this will always be the literal string "salt" and will be ignored.
-	 @return string The result of calling `Security::salt(null);`
+	 * @return string The result of calling `Security::getSalt();`
 	 */
 	private function securitySaltHelper($salt) {
-		return call_user_func('\Cake\Utility\Security::salt', null);
+		return call_user_func('\Cake\Utility\Security::getSalt');
 	}
 
 	/**
@@ -402,10 +402,10 @@ class ConfigReadShell extends Shell {
 				'default' => false,
 				'help' => __('Encode all output using PHP\'s `serialize()` method. Makes the Shell\'s output suitable for consumption by other PHP console scripts. Always overrides the --bash option. A single requested key will be serialized directly. Multiple requested keys will be combined into an associative array with the provided arguments as key names and then serialized.'),
 			])
-			->description(
+			->setDescription(
 				__('Provides CLI access to variables defined in the Configure class of the host CakePHP application. Will output the value of any keys passed as arguments. Equivelant to `Configure::read(\'Key.Name\')`. Unrecognized keys will produce empty string or `null` output.')
 			)
-			->epilog(
+			->setEpilog(
 				__('Provide the Key.name(s) to fetch from Configure::read() as arguments. Multiple keys may be specified, separated by spaces.')
 			);
 

--- a/src/Shell/ConfigReadShell.php
+++ b/src/Shell/ConfigReadShell.php
@@ -96,7 +96,7 @@ class ConfigReadShell extends Shell {
 
 		if (empty($this->args)) {
 			$this->_displayHelp('');
-			$this->error(__('No Configure keys provided.'));
+			$this->abort(__('No Configure keys provided.'));
 		}
 
 		// All other output should not be processed by the Shell.

--- a/tests/TestCase/Shell/ConfigReadShellTest.php
+++ b/tests/TestCase/Shell/ConfigReadShellTest.php
@@ -88,10 +88,10 @@ class ConfigReadShellTest extends TestCase {
 	 */
 	public static function setUpBeforeClass() {
 		// Prime the ConnectionManager with some configs.
-		ConnectionManager::config(self::$datasources);
+		ConnectionManager::setConfig(self::$datasources);
 
 		// Prime the security salt.
-		Security::salt(self::$salt);
+		Security::setSalt(self::$salt);
 	}
 
 	/**
@@ -104,7 +104,7 @@ class ConfigReadShellTest extends TestCase {
 			ConnectionManager::drop($ds);
 		}
 
-		Security::salt('');
+		Security::setSalt('');
 	}
 
 	/**
@@ -206,26 +206,29 @@ class ConfigReadShellTest extends TestCase {
 			'_displayHelp', 'error',
 		];
 
-		$this->io = $this->getMock('\Cake\Console\ConsoleIo', [], [], '', false);
+		$this->io = $this->getMockBuilder('\Cake\Console\ConsoleIo')
+			->disableOriginalConstructor()
+			->getMock();
 		$this->io->expects($this->any())
 			->method('out')
 			->with($this->anything())
 			->will($this->returnCallback([$this, 'outputCollector']));
 
-
 		$class = $this->getSUTClassName();
 		$mockedMethods = array_merge($defaultMocks, $additionalMocks);
-		$shell = $this->getMock(
-			$class,
-			$mockedMethods,
-			[$this->io]
-		);
+		$shell = $this->getMockBuilder($class)
+			->setMethods($mockedMethods)
+			->setConstructorArgs([$this->io])
+			->getMock();
 
 		$shell->expects($this->any())
 			->method('error')
 			->with($this->anything())
 			->will($this->returnCallback([$this, 'outputCollector']));
-		$shell->OptionParser = $this->getMock('\Cake\Console\ConsoleOptionParser', [], [null, false]);
+		$shell->OptionParser = $this->getMockBuilder('\Cake\Console\ConsoleOptionParser')
+			->setMethods([])
+			->setConstructorArgs([null, false])
+			->getMock();
 		$shell->params = [
 			'help' => false,
 			'verbose' => false,
@@ -253,7 +256,7 @@ class ConfigReadShellTest extends TestCase {
 		$this->Shell->expects($this->once())
 			->method('_displayHelp');
 
-		Cache::config('_cake_core_', [
+		Cache::setConfig('_cake_core_', [
 			'className' => 'File',
 		]);
 		$this->Shell->startup();
@@ -481,7 +484,6 @@ class ConfigReadShellTest extends TestCase {
 			],
 		];
 	}
-
 
 	/**
 	 * test main(), requesting "special" config keys.

--- a/tests/TestCase/Shell/ConfigReadShellTest.php
+++ b/tests/TestCase/Shell/ConfigReadShellTest.php
@@ -203,7 +203,7 @@ class ConfigReadShellTest extends TestCase {
 	 */
 	protected function initSUT($additionalMocks = []) {
 		$defaultMocks = [
-			'_displayHelp', 'error',
+			'_displayHelp', 'abort',
 		];
 
 		$this->io = $this->getMockBuilder('\Cake\Console\ConsoleIo')
@@ -222,7 +222,7 @@ class ConfigReadShellTest extends TestCase {
 			->getMock();
 
 		$shell->expects($this->any())
-			->method('error')
+			->method('abort')
 			->with($this->anything())
 			->will($this->returnCallback([$this, 'outputCollector']));
 		$shell->OptionParser = $this->getMockBuilder('\Cake\Console\ConsoleOptionParser')

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -52,7 +52,7 @@ Configure::write('App', [
 if (!getenv('db_dsn')) {
 	putenv('db_dsn=sqlite:///:memory:');
 }
-ConnectionManager::config('test', ['url' => getenv('db_dsn')]);
+ConnectionManager::setConfig('test', ['url' => getenv('db_dsn')]);
 
 Plugin::load('ConfigReadShell', [
 	'path' => dirname(dirname(__FILE__)) . DS,


### PR DESCRIPTION
* Resolves decprecation warnings from Cake 3.6 core.
* Updates PHPUnit to v6.x.
* Updates tests to use `->getMockBuilder()` instead of `getMock()`.
* Fixes up Travis builds and Coveralls reports.

⚠️ This _may_ be a backwards-incompatible change. I'm not sure how far back `::getConfig()` is available in the Cake core. These changes will only work with versions of Cake that support that. To be safe, I recommend incrementing at least the minor version number.